### PR TITLE
Added additional null check to prevent App crash

### DIFF
--- a/android/src/main/java/com/facebook/react/modules/email/EmailModule.java
+++ b/android/src/main/java/com/facebook/react/modules/email/EmailModule.java
@@ -39,26 +39,29 @@ public class EmailModule extends ReactContextBaseJavaModule {
         // First create an intent with only the package name of the first registered email app
         // and build a picked based on it
         Intent intentChooser = pm.getLaunchIntentForPackage(ri.activityInfo.packageName);
-        Intent openInChooser = Intent.createChooser(intentChooser, title);
 
-        // Then create a list of LabeledIntent for the rest of the registered email apps
-        List<LabeledIntent> intentList = new ArrayList<LabeledIntent>();
-        for (int i = 1; i < resInfo.size(); i++) {
-            // Extract the label and repackage it in a LabeledIntent
-            ri = resInfo.get(i);
-            String packageName = ri.activityInfo.packageName;
-            Intent intent = pm.getLaunchIntentForPackage(packageName);
+        if (intentChooser != null) {
+          Intent openInChooser = Intent.createChooser(intentChooser, title);
 
-            if (intent != null) {
+          // Then create a list of LabeledIntent for the rest of the registered email apps
+          List<LabeledIntent> intentList = new ArrayList<LabeledIntent>();
+          for (int i = 1; i < resInfo.size(); i++) {
+              // Extract the label and repackage it in a LabeledIntent
+              ri = resInfo.get(i);
+              String packageName = ri.activityInfo.packageName;
+              Intent intent = pm.getLaunchIntentForPackage(packageName);
+
+              if (intent != null) {
                 intentList.add(new LabeledIntent(intent, packageName, ri.loadLabel(pm), ri.icon));
-            }
-        }
+              }
+          }
 
-        LabeledIntent[] extraIntents = intentList.toArray(new LabeledIntent[intentList.size()]);
-        // Add the rest of the email apps to the picker selection
-        openInChooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraIntents);
-        openInChooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        getCurrentActivity().startActivity(openInChooser);
+          LabeledIntent[] extraIntents = intentList.toArray(new LabeledIntent[intentList.size()]);
+          // Add the rest of the email apps to the picker selection
+          openInChooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraIntents);
+          openInChooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          getCurrentActivity().startActivity(openInChooser);
+        }
       }
   }
 }


### PR DESCRIPTION
## Whats this? 
We've gotten a few reports in Sentry about our App crashing coming from this library.  I've written a fix for this. The drawback of this change is that the user will not get any feedback, but the method will not crash the app anymore. No window displaying possible apps to run is shown anymore. If you want a good view of the changes, i suggest using the ignore whitespace option (use the gear icon).  

## Exception data:
```txt
java.lang.NullPointerException: Attempt to invoke virtual method 'int android.content.Intent.getFlags()' on a null object reference
    at android.content.Intent.createChooser(Intent.java:930)
    at android.content.Intent.createChooser(Intent.java:891)
    at com.facebook.react.modules.email.EmailModule.open(EmailModule.java:42)
    at java.lang.reflect.Method.invoke(Method.java)
    at java.lang.reflect.Method.invoke(Method.java:372)
    at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
    at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:158)
    at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
    at android.os.Handler.handleCallback(Handler.java:739)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
    at android.os.Looper.loop(Looper.java:145)
    at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)
    at java.lang.Thread.run(Thread.java:818)
```

## How to test
1. Use an Android simulator with API version 22 without Google Services. 
2. Run a project and make sure it calls `openInbox();` somewhere. 

The device familiy in the report was SM-J320FN (Samsung) with Android 5.1.1. 