### PR TITLE
Android: add an optional param to start the activity in the current task

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ openInbox()
 - [`message`](#message)
 - [`cancelLabel`](#cancelLabel)
 - [`removeText`](#removeText)
+- [`newTask`](#newTask)
 
 ### `title`
 
@@ -88,6 +89,15 @@ If true, not text will be show above the ActionSheet or Intent. Default value is
 | -------- | -------- | -------- |
 | boolean  | No       | false    |
 
+### `newTask`
+
+If true, the email Intent will be started in a new Android task. Else, the Intent will be launched in the current task.
+
+Read more about Android tasks [here](https://developer.android.com/guide/components/activities/tasks-and-back-stack).
+
+| Type     | Required | Default   | Platform |
+| -------- | -------- | --------- | -------- |
+| boolean  | No       | true      | Android  |
 
 ## Authors
 

--- a/android/src/main/java/com/facebook/react/modules/email/EmailModule.java
+++ b/android/src/main/java/com/facebook/react/modules/email/EmailModule.java
@@ -29,7 +29,7 @@ public class EmailModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void open(final String title) {
+  public void open(final String title, final boolean newTask) {
     Intent emailIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("mailto:"));
     PackageManager pm = getCurrentActivity().getPackageManager();
 
@@ -59,7 +59,9 @@ public class EmailModule extends ReactContextBaseJavaModule {
           LabeledIntent[] extraIntents = intentList.toArray(new LabeledIntent[intentList.size()]);
           // Add the rest of the email apps to the picker selection
           openInChooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraIntents);
-          openInChooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          if (newTask) {
+            openInChooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          }
           getCurrentActivity().startActivity(openInChooser);
         }
       }

--- a/index.android.js
+++ b/index.android.js
@@ -29,6 +29,11 @@ export async function openInbox(options = {}) {
     text = '';
   }
 
-  NativeModules.Email.open(text);
+  let newTask = true;
+  if ("newTask" in options) {
+    newTask = options.newTask;
+  }
+
+  NativeModules.Email.open(text, newTask);
   return;
 }


### PR DESCRIPTION
Adds an optional param `newTask` for the Android version of the API. Setting it explicitly to `false` will start the activity in the current Android task. It's an optional param, with a default value of `true`.

Resolves https://github.com/leanmotherfuckers/react-native-email-link/issues/29